### PR TITLE
Update RECOIL to 6.4.4

### DIFF
--- a/recoil.h
+++ b/recoil.h
@@ -23,22 +23,22 @@ void RECOIL_Delete(RECOIL *self);
 /**
  * RECOIL version - micro part.
  */
-#define RECOIL_VERSION_MICRO 0
+#define RECOIL_VERSION_MICRO 4
 
 /**
  * RECOIL version as a string.
  */
-#define RECOIL_VERSION "6.4.0"
+#define RECOIL_VERSION "6.4.4"
 
 /**
  * Years RECOIL was created in.
  */
-#define RECOIL_YEARS "2009-2023"
+#define RECOIL_YEARS "2009-2024"
 
 /**
  * Short credits for RECOIL.
  */
-#define RECOIL_CREDITS "Retro Computer Image Library (C) 2009-2023 Piotr Fusik\n"
+#define RECOIL_CREDITS "Retro Computer Image Library (C) 2009-2024 Piotr Fusik\n"
 
 /**
  * Short license notice.
@@ -186,7 +186,7 @@ int RECOIL_GetColors(RECOIL *self);
  * Converts the decoded picture to palette-indexed.
  * Returns palette of 256 0xRRGGBB entries.
  * Call <code>GetColors()</code> for the actual number of colors.
- * Returns <code>null</code> if conversion fails,
+ * Returns <code>NULL</code> if conversion fails,
  * because there are more than 256 colors.
  * @param self This <code>RECOIL</code>.
  */


### PR DESCRIPTION
Fixes buffer overflows for malicious files in several formats, some revealed by security researchers.
Also fixes decoding some formats, most notably the Atari ST IMG which affected many files in this format.